### PR TITLE
Add code of conduct to project.

### DIFF
--- a/code_of_conduct.txt
+++ b/code_of_conduct.txt
@@ -1,0 +1,32 @@
+Digital Humanities Innovation Lab (DHIL) Code of Conduct
+
+
+Be considerate.
+Our work will be used by other people, and we in turn will depend on the work of others. Any decision we take will affect users and colleagues, and we should take those consequences into account when making decisions. Our contributions to DHIL projects will impact the work of others. For example, changes to code, infrastructure, policy, documentation, and translations during a release may negatively impact others' work.
+
+
+Be respectful.
+The DHIL community and its members treat one another with respect. Everyone can make a valuable contribution to these projects. We may not always agree, but disagreement is no excuse for poor behaviour and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one. Unacceptable behaviour includes but is not limited to conduct or speech which might be considered sexist, racist, homophobic, transphobic, ableist, or otherwise discriminatory or offensive in nature. We expect members of the DHIL community to be respectful when dealing with other contributors as well as with people outside DHIL projects and with users of these projects.
+
+
+Be collaborative.
+Collaboration is central to the DHIL and to the larger free software community. This collaboration involves individuals working with others in teams, teams working with each other within the DHIL, and individuals and teams within the DHIL working with other projects outside. This collaboration reduces redundancy, and improves the quality of our work. Internally and externally, we should always be open to collaboration. Wherever possible, we should work closely with upstream projects and others in the free software community to coordinate our technical, advocacy, documentation, and other work. Our work should be done transparently and we should involve as many interested parties as early as possible. If we decide to take a different approach than others, we will let them know early, document our work and inform others regularly of our progress.
+
+
+Reporting
+Conflicts in our community can take many forms. Disagreements, social and technical, are normal, but we do not allow them to persist and fester leaving others uncertain of the agreed direction. We expect individuals to first try to resolve conflicts between themselves in a constructive manner. We will not tolerate bullying or harassment of any member of the Drupal community.
+
+If you feel threatened or violated as a result of intimidating, bullying, harassing, abusive, discriminatory, derogatory, or demeaning conduct, please speak up and ask it to stop. If you do not feel that you can speak up, contact the DHIL immediately with evidence of the incident. Incidents of bullying and harassment can be reported privately and will be treated seriously and discreetly. Please reach the DHIL at dhil@sfu.ca.
+
+Please speak up if you notice someone else being subjected to such behaviour. Refer people to our Code of Conduct and point out such behaviour is unwelcome.
+
+
+When we are unsure, we ask for help.
+Nobody knows everything, and nobody is expected to be perfect in the DHIL community. Asking questions avoids many problems down the road, and so questions are encouraged. Those who are asked questions should be responsive and helpful. However, when asking a question, care must be taken to do so in an appropriate place.
+
+
+Step down considerately.
+Members of every project come and go and the DHIL is no different. When somebody leaves or disengages from the project, in whole or in part, we ask that they do so in a way that minimizes disruption to the project. This means they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+
+Portions derived from the Drupal and Slack code of conduct. Last update: 13-NOV-2016


### PR DESCRIPTION
Add code of conduct to project as per Nov. 8, 2016 DHIL meeting.