### PR TITLE
Report exact matches in the metadata column for the report view.

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -460,12 +460,28 @@ declare function app:document-similarities($node as node(), $model as map(*)) as
     let $similarities := document:similar-documents($model('document'))
     let $cosines := $similarities[@data-type='cos']
     let $levens := $similarities[@data-type='lev']
+    let $exact := $similarities[@data-type='exact']
 
     return
         if(count($similarities) = 0) then
             (<i>None found</i>)
         else
             <div>
+                <div class='panel-heading'>Exact Matches</div>
+                <div class='panel-body'>{
+                    if(count($exact) = 0) then
+                        <i>None found</i>
+                    else
+                        <ul> {
+                            for $link in $exact
+                            let $doc := collection:fetch($link/@href)
+                            return
+                                <li class="{$link/@class}">
+                                    {app:link-view($link/@href, document:title($doc))}<br/>
+                                    <a href='compare-docs.html?a={document:id($model('document'))}&amp;b={document:id($doc)}'>Compare</a>
+                                </li>
+                        } </ul>
+                }</div>
                 <div class='panel-heading'>Levenshtein Matches</div>
                 <div class='panel-body'>{
                     if(count($levens) = 0) then


### PR DESCRIPTION
The report list counts exact matches, but they aren't displayed in the
metadat column. They should be.

fixes sfu-dhil/wilde#24