### PR TITLE
Changes to fix duplication of text

### DIFF
--- a/city-nocache.html
+++ b/city-nocache.html
@@ -4,16 +4,13 @@
   <div class="row">
     <div class="page-header">
       <h1>Browse by City</h1>
-      <p> Below is the complete list of news reports on Wilde’s trials organised by city. Select the
-        city to navigate to the list of news reports published from that city. Next to each city of
-        publication is a number, which indicates the number of reports published from that city.
-      </p>
+      <p>Select one of the cities below to discover news reports on Wilde's trials published from that city. The number next to each city indicates the number of reports published in that city. </p>
     </div>
   </div>
   <div class="row">
-    <div class='col-md-6'>
-      <p> Select one of the cities below to discover news reports on Wilde's trials published from that city. The number next to each city indicates the number of reports published in that city. </p> 
+    <div class="col-md-12">
       <div data-template="app:browse-city"/>
     </div>
   </div>
 </div>
+

--- a/date-nocache.html
+++ b/date-nocache.html
@@ -4,16 +4,18 @@
     <div class="row">
         <div class="page-header">
             <h1>Browse by Date</h1>
-            <p> Below is the complete list of news reports on Wilde’s trials organised by date.
-                Select the date to navigate to the list of news reports published on that date. Next
-                to each date of publication is a number, which indicates the number of reports
-                published on that date. </p>
-        </div>
-    </div>
-    <div class="row">
-        <p> Select one of the dates below to discover news reports on Wilde's trials published on that date. The number next to each date indicates the number of reports published on that date. </p>
-        <div class="col-md-12">
-            <div data-template="app:browse-date"/>
+            <p> Select one of the dates below to discover news reports on Wilde's trials published on that date. The number next to each date indicates the number of reports published on that date. </p>
         </div>
     </div>
 </div>
+<div class="row">
+        <div class="col-md-12">
+            <div data-template="app:browse-date"/>
+     
+        </div>
+</div>
+</div>
+     
+     
+                
+

--- a/language-nocache.html
+++ b/language-nocache.html
@@ -4,16 +4,10 @@
     <div class="row">
         <div class="page-header">
             <h1>Browse by Language</h1>
-            <p> Below is a list of languages. Select one of the languages to navigate to a list of
-                news reports on Wilde's trials which were published in that language. The number
-                next to each language indicates the number of reports published in that language.
-            </p>
-        </div>
-    </div>
-    <div class="row">
-      <div class='col-md-12'>
           <p> Select one of the languages below to discover news reports on Wilde's trials published in that language. The number next to each language indicates the number of reports published in that language. </p> 
             <div data-template="app:browse-language"/>
-        </div>
+        
     </div>
 </div>
+</div>
+

--- a/language-nocache.html
+++ b/language-nocache.html
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround"
+<div xmlns="http://www.w3.org/1999/xhtml"
+    data-template="templates:surround"
     data-template-with="templates/page.html" data-template-at="content">
     <div class="row">
         <div class="page-header">
             <h1>Browse by Language</h1>
           <p> Select one of the languages below to discover news reports on Wilde's trials published in that language. The number next to each language indicates the number of reports published in that language. </p> 
+        </div>
+    </div>
+    
+    <div class="row">
+        <div class="col-md-12">
             <div data-template="app:browse-language"/>
         
     </div>
 </div>
 </div>
-

--- a/region-details.html
+++ b/region-details.html
@@ -7,11 +7,7 @@
       <p>Listed below are all the news reports on Wilde’s trials that were published in <span
           data-template="app:parameter" data-template-name="region"/>. Select one of the reports to
         navigate directly to it.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class='col-md-6'>
-      <p>Listed below are all the news reports on Wilde’s trials that were published in one specific region. Select one of the reports to navigate directly to it.</p>
+      
       <div data-template="app:details-region"/>
     </div>
   </div>

--- a/region-nocache.html
+++ b/region-nocache.html
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround"
+<div xmlns="http://www.w3.org/1999/xhtml"
+  
+  data-template="templates:surround"
   data-template-with="templates/page.html" data-template-at="content">
   <div class="row">
     <div class="page-header">
       <h1>Browse by Region</h1>
+      <p> Select one of the regions below to discover news reports on Wilde's trials published from that region. The number next to each region indicates the number of reports published in that region. </p>
     </div>
   </div>
+
   <div class="row">
-      <p> Select one of the regions below to discover news reports on Wilde's trials published from that region. The number next to each region indicates the number of reports published in that region. </p>
+    <div class="col-md-12">
       <div data-template="app:browse-region"/>
     </div>
 </div>
 </div>
+
 


### PR DESCRIPTION
I made changes to these pages as text was duplicated. You can see the problem on these pages on the Wilde site. But I am not sure I have kept all the right tags. Does this look okay to you? If so, I will change the rest of the report pages in the same way.