### PR TITLE
Sort lists of reports by sortable name

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -21,7 +21,6 @@ declare namespace array="http://www.w3.org/2005/xpath-functions/array";
 declare namespace xhtml='http://www.w3.org/1999/xhtml';
 declare default element namespace "http://www.w3.org/1999/xhtml";
 
-
 (:
     Build a link to a report.
 :)
@@ -346,6 +345,8 @@ declare function app:browse-items($name as xs:string, $query as xs:string, $page
             let $count := $map($key)
             let $percent := (math:log10($count) div $max)
             let $output := if ($query = 'language') then lang:code2lang($key) else $key
+            let $m := head($metas[@content = $key])
+            let $sort := if($m[@data-sortable]) then $m/@data-sortable else $output
             return
                 map{$key: 
                     map{
@@ -353,7 +354,8 @@ declare function app:browse-items($name as xs:string, $query as xs:string, $page
                         'percent': $percent,
                         'output': $output,
                         'query': $query,
-                        'page': $page
+                        'page': $page,
+                        'sort': $sort
                 }
             }
     )
@@ -369,7 +371,7 @@ declare function app:browse-list($map as map(*), $append as xs:string?){
         <ul class="browse-list">{
             for $key in map:keys($map)
             let $item := map:get($map, $key)
-            order by xs:string($item('output'))
+            order by xs:string($item('sort'))
                 return
                 <li data-count="{$item('count')}" data-value="{$item('output')}" style="--height: {$item('percent') * 100}%" data-region="{$item('region')}">
                     <a href="{$item('page')}-details.html?{$item('query')}={$key}{$append}">

--- a/modules/collection.xql
+++ b/modules/collection.xql
@@ -164,7 +164,7 @@ declare function collection:documents($name as xs:string, $value as xs:string) a
     return
         for $doc in $collection
         where util:document-name($doc) != 'reports.xpr'
-        order by document:region($doc), document:publisher($doc), document:date($doc)
+        order by document:sortable($doc)
         return $doc
 };
 

--- a/modules/collection.xql
+++ b/modules/collection.xql
@@ -8,6 +8,8 @@ module namespace collection="http://dhil.lib.sfu.ca/exist/wilde-app/collection";
 import module namespace config="http://dhil.lib.sfu.ca/exist/wilde-app/config" at "config.xqm";
 import module namespace functx='http://www.functx.com';
 import module namespace document="http://dhil.lib.sfu.ca/exist/wilde-app/document" at "document.xql";
+import module namespace util="http://exist-db.org/xquery/util";
+import module namespace xmldb="http://exist-db.org/xquery/xmldb";
 
 declare namespace xhtml='http://www.w3.org/1999/xhtml';
 declare default element namespace "http://www.w3.org/1999/xhtml";
@@ -143,7 +145,8 @@ declare function collection:previous($document) as node()? {
  :)
 declare function collection:documents() as node()* {
     let $collection := collection:collection()
-    for $doc in $collection 
+    for $doc in $collection
+        where util:document-name($doc) != 'reports.xpr'
         order by document:region($doc), document:publisher($doc), document:date($doc), document:id($doc)
         return $doc
 };
@@ -160,6 +163,7 @@ declare function collection:documents($name as xs:string, $value as xs:string) a
     let $collection := collection($config:data-root)[.//meta[@name=$name and @content=$value]]
     return
         for $doc in $collection
+        where util:document-name($doc) != 'reports.xpr'
         order by document:region($doc), document:publisher($doc), document:date($doc)
         return $doc
 };

--- a/modules/document.xql
+++ b/modules/document.xql
@@ -134,6 +134,15 @@ declare function document:collection($node as node()) as xs:string {
     util:unescape-uri(util:collection-name($node), "UTF-8")
 };
 
+declare function document:sortable($node as node()) as xs:string {
+    let $meta := root($node)//meta[@name='wr.sortable']
+    return
+        if($meta) then
+            $meta/@content
+        else
+            document:title($node)
+};
+
 declare function document:translations($node as node()) as xs:string* {
   root($node)//div[@id='translation']/@lang/string()
 };

--- a/modules/document.xql
+++ b/modules/document.xql
@@ -126,6 +126,14 @@ declare function document:language($node as node()) as xs:string {
         ''      
 };
 
+declare function document:filename($node as node()) as xs:string {
+    util:unescape-uri(util:document-name($node), "UTF-8")
+};
+
+declare function document:collection($node as node()) as xs:string {
+    util:unescape-uri(util:collection-name($node), "UTF-8")
+};
+
 declare function document:translations($node as node()) as xs:string* {
   root($node)//div[@id='translation']/@lang/string()
 };


### PR DESCRIPTION
Also restores list.html which is no longer cached. Also excludes reports.xpr
from most files lists (it's a mistake to upload it, but it does happen).

fixes sfu-dhil/wilde#94