### PR TITLE
continuing fixes to paragraph compare.

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -22,8 +22,6 @@ import module namespace similarity = "http://dhil.lib.sfu.ca/exist/wilde/similar
 import module namespace stats = "http://dhil.lib.sfu.ca/exist/wilde/stats" at "stats.xql";
 import module namespace tx = "http://dhil.lib.sfu.ca/exist/wilde/transform" at "transform.xql";
 
-import module namespace console="http://exist-db.org/xquery/console";
-
 declare namespace array = "http://www.w3.org/2005/xpath-functions/array";
 declare namespace string = "java:org.apache.commons.lang3.StringUtils";
 declare namespace wilde = "http://dhil.lib.sfu.ca/wilde";
@@ -1219,9 +1217,10 @@ declare function app:compare-paragraphs($node as node(), $model as map(*)) {
       </div>
       {
         for $other at $i in $pa
-          let $q := local:find-similar("levenshtein", $pb, $other)  
-          let $similarity := if ($q) then
-            format-number($q//a[@data-paragraph = $other/@id]/@data-similarity cast as xs:float, "###.#%")
+          let $q := local:find-similar("levenshtein", $pb, $other)
+          let $n := $q//a[@data-paragraph = $other/@id]/@data-similarity
+          let $similarity := if ($n) then
+            format-number($n cast as xs:float, "###.#%")
           else
             ""
           

--- a/resources/js/page/compare.js
+++ b/resources/js/page/compare.js
@@ -43,13 +43,17 @@
             var $d = $this.find('.paragraph-d');
             
             if (! b) {
-                $d.html("No similar paragraph.");
+                $d.html("<em>No similar paragraph</em>");
             } else {
                 var diff = dmp.diff_main(a, b);
                 dmp.diff_cleanupSemantic(diff);
                 var html = htmlize(diff);
                 $d.html('<p>' + html + '</p>');
-                $d.append("Match: " + $this.data('score'));
+                if($this.data('score') !== '%') {
+                  $d.append("<em>Match: " + $this.data('score') + "</em>");
+                } else {
+                  $d.append("<em>Too short to calculate match</em>");
+                }
             }
         });
     });


### PR DESCRIPTION
very short paragraphs (less than 64 characters) were not compared, so no
   match data is available. But the code that displays matches expected it and
   was crashng. Not now.